### PR TITLE
Feature/cluster

### DIFF
--- a/definitions/coordinator.go
+++ b/definitions/coordinator.go
@@ -2,7 +2,9 @@ package definitions
 
 import "github.com/google/uuid"
 
-// Coordinator defines the interface for coordinating leader election and handling leader failures across a cluster.
+// Coordinator defines the interface for assigning leaders nodes for each trigger processor.
+// The coordinator elects a leader for each trigger processor and monitors the leader nodes.
+// If a node drops, the coordinator is responsible for reassigning the leader.
 type Coordinator interface {
 	// IsLeader checks if the current instance is the leader for the trigger processor.
 	// If the current instance is the coordinator, it will also assign the leader for the trigger processor.

--- a/definitions/coordinator.go
+++ b/definitions/coordinator.go
@@ -10,4 +10,9 @@ type Coordinator interface {
 	// - bool: True if the current instance is the leader, false otherwise.
 	// - error: An error if the check fails.
 	IsLeader(tpID string) (bool, error)
+
+	// Close terminates the leader election process and stops being the coordinator(if currently is).
+	// Returns:
+	// - error: An error if the termination fails.
+	Close() error
 }

--- a/definitions/coordinator.go
+++ b/definitions/coordinator.go
@@ -1,0 +1,13 @@
+package definitions
+
+// Coordinator defines the interface for coordinating leader election and handling leader failures across a cluster.
+type Coordinator interface {
+	// IsLeader checks if the current instance is the leader for the trigger processor.
+	// If the current instance is the coordinator, it will also assign the leader for the trigger processor.
+	// Parameters:
+	// - tpID: The unique identifier of the trigger processor.
+	// Returns:
+	// - bool: True if the current instance is the leader, false otherwise.
+	// - error: An error if the check fails.
+	IsLeader(tpID string) (bool, error)
+}

--- a/definitions/coordinator.go
+++ b/definitions/coordinator.go
@@ -1,5 +1,7 @@
 package definitions
 
+import "github.com/google/uuid"
+
 // Coordinator defines the interface for coordinating leader election and handling leader failures across a cluster.
 type Coordinator interface {
 	// IsLeader checks if the current instance is the leader for the trigger processor.
@@ -9,7 +11,7 @@ type Coordinator interface {
 	// Returns:
 	// - bool: True if the current instance is the leader, false otherwise.
 	// - error: An error if the check fails.
-	IsLeader(tpID string) (bool, error)
+	IsLeader(tpID uuid.UUID) (bool, error)
 
 	// Close terminates the leader election process and stops being the coordinator(if currently is).
 	// Returns:

--- a/definitions/flow.go
+++ b/definitions/flow.go
@@ -41,7 +41,7 @@ type SimpleTriggerProcessor struct {
 	Config       map[string]interface{} `json:"config"`        // Config holds the specific configuration for the trigger processor.
 	ScheduleType ScheduleType           `json:"schedule_type"` // ScheduleType defines the type of scheduling (event-driven or cron-driven).
 	CronExpr     string                 `json:"cron_expr"`     // CronExpr is the cron expression used for scheduling, applicable if ScheduleType is CronDriven.
-	EventName    string                 `json:"event_name"`    // EventName is the name of the event to listen to, applicable if ScheduleType is EventDriven.
 	LogLevel     logrus.Level           `json:"log_level"`     // LogLevel defines the logging level used for this trigger processor.
+	SingleNode   bool                   `json:"single_node"`   // SingleNode defines wether or not this trigger processor should run on a single node when running in a cluster.
 	Enabled      bool                   `json:"enabled"`       // Enabled indicates if the processor is enabled.
 }

--- a/definitions/leader_selector.go
+++ b/definitions/leader_selector.go
@@ -13,8 +13,8 @@ type LeaderSelector interface {
 	// - error: An error if the check fails.
 	IsLeader() (bool, error)
 
-	// Stop terminates the leader election process.
+	// Close terminates the leader election process.
 	// Returns:
 	// - error: An error if the termination fails.
-	Stop() error
+	Close() error
 }

--- a/definitions/leader_selector.go
+++ b/definitions/leader_selector.go
@@ -7,30 +7,30 @@ type LeaderSelector interface {
 	// - error: An error if the initiation fails.
 	Start() error
 
-	// IsLeader checks if the current instance is the leader.
+	// IsLeader checks if the current participant is the leader.
 	// Returns:
 	// - bool: True if the current instance is the leader, false otherwise.
 	// - error: An error if the check fails.
 	IsLeader() (bool, error)
 
-	// Nodes retrieves the list of nodes participating in the leader election.
+	// Participants retrieves the list of nodes participating in the leader election.
 	// Returns:
 	// - []string: A slice of node identifiers.
 	// - error: An error if the retrieval fails.
-	Nodes() ([]string, error)
+	Participants() ([]string, error)
 
 	// Close terminates the leader election process.
 	// Returns:
 	// - error: An error if the termination fails.
 	Close() error
 
-	// NodeName retrieves the name of the current node.
+	// ParticipantName retrieves the name of the current participant.
 	// Returns:
 	// - string: The name of the current node.
-	NodeName() string
+	ParticipantName() string
 
-	// NodeChangeChannel returns a channel that receives updates about node changes.
+	// ParticipantsChangeChannel returns a channel that receives updates about node changes.
 	// Returns:
 	// - <-chan []string: A receive-only channel that provides slices of the nodes.
-	NodeChangeChannel() <-chan []string
+	ParticipantsChangeChannel() <-chan []string
 }

--- a/definitions/leader_selector.go
+++ b/definitions/leader_selector.go
@@ -28,4 +28,9 @@ type LeaderSelector interface {
 	// Returns:
 	// - string: The name of the current node.
 	NodeName() string
+
+	// NodeChangeChannel returns a channel that receives updates about node changes.
+	// Returns:
+	// - <-chan []string: A receive-only channel that provides slices of the nodes.
+	NodeChangeChannel() <-chan []string
 }

--- a/definitions/leader_selector.go
+++ b/definitions/leader_selector.go
@@ -23,4 +23,9 @@ type LeaderSelector interface {
 	// Returns:
 	// - error: An error if the termination fails.
 	Close() error
+
+	// NodeName retrieves the name of the current node.
+	// Returns:
+	// - string: The name of the current node.
+	NodeName() string
 }

--- a/definitions/leader_selector.go
+++ b/definitions/leader_selector.go
@@ -1,0 +1,20 @@
+package definitions
+
+// LeaderSelector defines the interface for leader election mechanisms.
+type LeaderSelector interface {
+	// Start initiates the leader election process.
+	// Returns:
+	// - error: An error if the initiation fails.
+	Start() error
+
+	// IsLeader checks if the current instance is the leader.
+	// Returns:
+	// - bool: True if the current instance is the leader, false otherwise.
+	// - error: An error if the check fails.
+	IsLeader() (bool, error)
+
+	// Stop terminates the leader election process.
+	// Returns:
+	// - error: An error if the termination fails.
+	Stop() error
+}

--- a/definitions/leader_selector.go
+++ b/definitions/leader_selector.go
@@ -13,6 +13,12 @@ type LeaderSelector interface {
 	// - error: An error if the check fails.
 	IsLeader() (bool, error)
 
+	// Nodes retrieves the list of nodes participating in the leader election.
+	// Returns:
+	// - []string: A slice of node identifiers.
+	// - error: An error if the retrieval fails.
+	Nodes() ([]string, error)
+
 	// Close terminates the leader election process.
 	// Returns:
 	// - error: An error if the termination fails.


### PR DESCRIPTION
Added definitions for coordinator and leader selector to coordinator to allow a trigger processor to run on a single node. 
Also, added `SingleNode` on trigger processor definition.
